### PR TITLE
Fixed sample output for API status to use numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,10 +376,10 @@ This will return the current status of API, like how much API time has been used
 
 ```javascript
   {
-    used_time: '4235.4',
-    total_available_time: '6000', 
-    running_sessions: '1',
-    sessions_limit: '1'
+    used_time: 4235.4,
+    total_available_time: 6000,
+    running_sessions: 1,
+    sessions_limit: 1
   }
 ```
 The time returned is in seconds.


### PR DESCRIPTION
The API Status method returns numbers, not strings, for each value.
