### PR TITLE
Updated README removed all true param

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,83 +70,59 @@ Fetches all available browsers.
 {
   'Windows':
     {
-      '7': 
+      '10':
         [
-        {
-          browser: 'ie',
-          browser_version: 8.0,
-        },
-        {
-          browser: 'firefox',
-          browser_version: 2.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        } ...
-        ],
-      'XP':
-        [
-        {
-          browser: 'ie',
-          browser_version: 7.0,
-        },
-        {
-          browser: 'firefox',
-          browser_version: 10.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        } ...
+          {
+            "browser": "chrome",
+            "browser_version": "83.0"
+          },
+          {
+            "browser": "chrome",
+            "browser_version": "84.0"
+          },
+          {
+            "browser": "chrome",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "ie",
+            "browser_version": "11.0"
+          },
+          {
+            "browser": "edge",
+            "browser_version": "insider preview"
+          }...
         ],
     },
   'OS X':
     {
-      'Snow Leopard':
+      'Catalina':
         [
-        {
-          browser: 'firefox',
-          browser_version: 11.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        }, ...
+          {
+            "browser": "chrome",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "edge",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "safari",
+            "browser_version": "13.1"
+          },
+          {
+            "browser": "firefox",
+            "browser_version": "79.0"
+          },
+          {
+            "browser": "firefox",
+            "browser_version": "80.0 beta"
+          }...
         ],
-      'Lion':
-        [
-        {
-          browser: 'firefox',
-          browser_version: 11.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        } ...
-        ],
-    },
-  'ios':
-    {
-      '4.0':
-        [
-        {
-          browser: "Mobile Safari",
-          browser_version: null,
-          devices: ["iPhone 4"],
-        }
-        ],
-      '6.0':
-        [
-        {
-          browser: "Mobile Safari",
-          browser_version: null,
-          devices: ["iPhone 4S (6.0)", "iPhone 5", "iPad 3rd (6.0)"],
-        }
-        ]
+      }...
     },
 }
-``` 
+```
 
 A flat parameter can also be passed to get browsers in a flat structure
 
@@ -155,97 +131,62 @@ A flat parameter can also be passed to get browsers in a flat structure
 ### Output
 
 ```javascript
-[
-{
-  device: null,
-  os_version: "8",
-  os: "Windows",
-  browser_version: "5.1",
-  browser: "safari"
-},
-{
-  device: null,
-  os_version: "8",
-  os: "Windows",
-  browser_version: "16.0",
-  browser: "firefox"
-},
-{
-  device: null,
-  os_version: "8",
-  os: "Windows",
-  browser_version: "17.0",
-  browser: "firefox"
-},
-{
-  device: null,
-  os_version: "8",
-  os: "Windows",
-  browser_version: "18.0",
-  browser: "firefox"
-},
-{
-  device: null,
-  os_version: "8",
-  os: "Windows",
-  browser_version: "10.0",
-  browser: "ie"
-}....
-``` 
-
-You can get beta/dev versions of browsers by using  "all" parameter:
-
-    GET /browsers?all=true
-  
-### Output
-
-```javascript
 {
   'Windows':
     {
-      'XP': 
+      '10':
         [
-        {
-          browser: 'ie',
-          browser_version: 7.0,
-        },
-        {
-          browser: 'firefox',
-          browser_version: '28.0 beta',
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        } ...
+          {
+            "browser": "chrome",
+            "browser_version": "83.0"
+          },
+          {
+            "browser": "chrome",
+            "browser_version": "84.0"
+          },
+          {
+            "browser": "chrome",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "ie",
+            "browser_version": "11.0"
+          },
+          {
+            "browser": "edge",
+            "browser_version": "insider preview"
+          }...
         ],
     },
   'OS X':
     {
-      'Snow Leopard':
+      'Catalina':
         [
-        {
-          browser: 'firefox',
-          browser_version: 11.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: '27.0 beta',
-        }, ...
+          {
+            "browser": "chrome",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "edge",
+            "browser_version": "85.0 beta"
+          },
+          {
+            "browser": "safari",
+            "browser_version": "13.1"
+          },
+          {
+            "browser": "firefox",
+            "browser_version": "79.0"
+          },
+          {
+            "browser": "firefox",
+            "browser_version": "80.0 beta"
+          }...
         ],
-      'Lion':
-        [
-        {
-          browser: 'firefox',
-          browser_version: 11.0,
-        },
-        {
-          browser: 'chrome',
-          browser_version: 14.0,
-        } ...
-        ],
+      }...
     },
 }
-``` 
+```
 
 ## Create a New Browser Worker
 A browser worker is simply a new browser instance. A user can start multiple browser worker at a time. All browser workers when created are pushed in a queue and they run when their turn comes. We make sure that your browser worker starts running as soon as possible. Your testing time is calculated from the time when browser worker starts running.


### PR DESCRIPTION
As `/browsers` returns all dev, beta & stable versions of browsers. `/browsers?all=true` returns the same. So, removing not required.